### PR TITLE
Update Java to 18, update Dependencies + Plugins, rework and extend CI

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -1,0 +1,20 @@
+name: Build on Push Request
+
+on: [pull_request]
+  
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '18'
+          distribution: 'adopt'
+
+      - name: Run clean install 
+        run: mvn clean install

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,29 +6,58 @@ on:
       - "v*"
 
 jobs:
-  build:
+  create_release:
+    name: Create release
     runs-on: ubuntu-latest
-
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: false
+          
+  build:
+    name: Build
+    needs: create_release
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+          - os: ubuntu-latest
+          - os: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
       
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          java-version: '17'
+          java-version: '18'
           distribution: 'adopt'
-      
       - name: Install rpm-build
         run: |
           sudo apt-get update
           sudo apt-get install rpm
-
-      - name: Run clean install
-        run: mvn clean install -Dskip.rpm=false
+        if: runner.os == 'Linux'
+      - name: Run clean install on Linux
+        run: mvn clean install -Dskip.rpm=false -Dskip.deb=false
+        if: runner.os == 'Linux'
+      - name: Run clean install on Windows
+        run: mvn clean install -D"skip.exe=false"
+        if: runner.os == 'Windows'
       
-      - name: Create Draft Release
-        uses: ncipollo/release-action@v1
+      - name: Upload release assets
+        uses: nanoufo/action-upload-artifacts-and-release-assets@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "target/mtgacollection*.rpm"
-          draft: true
+          path: target/mtgacollection*.???
+          upload-release-files: true
+          release-upload-url: ${{ needs.create_release.outputs.upload_url }}

--- a/jpackage-deb.sh
+++ b/jpackage-deb.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+jpackage \
+-n mtgacollection \
+--runtime-image ./target/jlink-image \
+--module hirsizlik.mtgacollection/hirsizlik.mtgacollection.main.MTGACollectionMain \
+-t deb \
+--description "A CLI program to see stats of your MTG-Arena card collection." \
+--app-version $1 \
+-d ./target \
+--license-file ./LICENSE \
+--verbose 

--- a/jpackage-exe.cmd
+++ b/jpackage-exe.cmd
@@ -1,0 +1,11 @@
+jpackage ^
+-n mtgacollection ^
+--runtime-image .\target\jlink-image ^
+--module hirsizlik.mtgacollection/hirsizlik.mtgacollection.main.MTGACollectionMain ^
+-t exe ^
+--description "A CLI program to see stats of your MTG-Arena card collection." ^
+--app-version %1 ^
+-d .\target ^
+--license-file .\LICENSE ^
+--win-console ^
+--verbose 

--- a/pom.xml
+++ b/pom.xml
@@ -18,12 +18,12 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.13.2</version>
+			<version>2.13.3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.2</version>
+			<version>2.13.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.xerial</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,10 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>17</java.version>
+		<java.version>18</java.version>
 		<skip.rpm>true</skip.rpm>
+		<skip.deb>true</skip.deb>
+		<skip.exe>true</skip.exe>
 	</properties>
 
 	<dependencies>
@@ -116,6 +118,7 @@
 							</goals>
 							<configuration>
 								<outputDirectory>${project.build.directory}/modules_copy</outputDirectory>
+								<excludeArtifactIds>sqlite-jdbc,log4j-core</excludeArtifactIds>
 							</configuration>
 						</execution>
 					</executions>
@@ -124,7 +127,7 @@
 				<plugin>
 					<groupId>org.moditect</groupId>
 					<artifactId>moditect-maven-plugin</artifactId>
-					<version>1.0.0.RC1</version>
+					<version>1.0.0.RC2</version>
 					<executions>
 						<execution>
 							<id>add-module-info-to-dependencies</id>
@@ -154,7 +157,9 @@
 							</goals>
 							<configuration>
 								<modulePath>
-									<path>${project.build.directory}/jar:${project.build.directory}/modules_generated:${project.build.directory}/modules_copy</path>
+									<path>${project.build.directory}/jar</path>
+									<path>${project.build.directory}/modules_generated</path>
+									<path>${project.build.directory}/modules_copy</path>
 								</modulePath>
 								<modules>
 									<module>hirsizlik.mtgacollection</module>
@@ -170,6 +175,7 @@
 								<noManPages>true</noManPages>
 								<stripDebug>true</stripDebug>
 								<noHeaderFiles>true</noHeaderFiles>
+								<jarInclusionPolicy>NONE</jarInclusionPolicy>
 							</configuration>
 						</execution>
 					</executions>
@@ -190,6 +196,37 @@
 								<executable>bash</executable>
 								<arguments>
 									<argument>${project.basedir}/jpackage-rpm.sh</argument>
+									<argument>${project.version}</argument>
+								</arguments>
+							</configuration>
+						</execution>
+						<execution>
+							<id>Creating a DEB Package via jpackage</id>
+							<phase>package</phase>
+							<goals>
+								<goal>exec</goal>
+							</goals>
+							<configuration>
+								<skip>${skip.deb}</skip>
+								<executable>bash</executable>
+								<arguments>
+									<argument>${project.basedir}/jpackage-deb.sh</argument>
+									<argument>${project.version}</argument>
+								</arguments>
+							</configuration>
+						</execution>
+						<execution>
+							<id>Creating a Windows Executable via jpackage</id>
+							<phase>package</phase>
+							<goals>
+								<goal>exec</goal>
+							</goals>
+							<configuration>
+								<skip>${skip.exe}</skip>
+								<executable>cmd</executable>
+								<arguments>
+									<argument>/C</argument>
+									<argument>${project.basedir}/jpackage-exe.cmd</argument>
 									<argument>${project.version}</argument>
 								</arguments>
 							</configuration>

--- a/src/hirsizlik.mtgacollection/hirsizlik/mtgacollection/properties/DataLoaderFactory.java
+++ b/src/hirsizlik.mtgacollection/hirsizlik/mtgacollection/properties/DataLoaderFactory.java
@@ -29,7 +29,8 @@ public class DataLoaderFactory {
 	private static DataLoader getDataLoaderByOsName(final String osName) {
 		return switch(osName)  {
 			case "Linux" -> new XdgDataLoader();
-			default -> throw new IllegalArgumentException(osName + " is not supported, use -p instead.");
+			default -> throw new IllegalArgumentException(osName + " is not supported, "
+					+ "use \"-p path/to/properties path/to/database\" instead (will be created there if missing).");
 		};
 	}
 }


### PR DESCRIPTION
* Update to the latest Java Version (no code changes needed)
* Dependency updates, Jackson and moditect-maven-plugin
* extend Action on Tag-Push, now deb and exe are built. Includes bunch of changes to pom.xml
* add Action for pull_request, to test if it even builds
* improve a error message on non-supported platforms like Windows