### PR TITLE
Inventory: filter Booster with no count

### DIFF
--- a/src/hirsizlik.mtgacollection/hirsizlik/mtgacollection/mapper/MapMtgaInventoryToInventory.java
+++ b/src/hirsizlik.mtgacollection/hirsizlik/mtgacollection/mapper/MapMtgaInventoryToInventory.java
@@ -42,7 +42,8 @@ public class MapMtgaInventoryToInventory implements Function<PlayerInventory, In
 
 	private List<Booster> mapBooster(final List<hirsizlik.mtgacollection.jackson.inventory.Booster> boosters){
 		return boosters.stream()
-			.map(b ->new Booster(b.getCount(), b.getCollationId(), b.getSetCode()))
+			.filter(b -> b.getCount() != null)// the inventory can contain booster with no count
+			.map(b -> new Booster(b.getCount(), b.getCollationId(), b.getSetCode()))
 			.toList();
 	}
 


### PR DESCRIPTION
means that you have none of these. No idea why they can show up.